### PR TITLE
all frame structs are clone-able now

### DIFF
--- a/scap/src/frame/mod.rs
+++ b/scap/src/frame/mod.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, Clone)]
 pub struct YUVFrame {
     pub display_time: u64,
     pub width: i32,
@@ -8,6 +9,7 @@ pub struct YUVFrame {
     pub chrominance_stride: i32,
 }
 
+#[derive(Debug, Clone)]
 pub struct RGBFrame {
     pub display_time: u64,
     pub width: i32,
@@ -15,12 +17,14 @@ pub struct RGBFrame {
     pub data: Vec<u8>,
 }
 
+#[derive(Debug, Clone)]
 pub struct RGB8Frame {
     pub display_time: u64,
     pub width: i32,
     pub height: i32,
 }
 
+#[derive(Debug, Clone)]
 pub struct RGBxFrame {
     pub display_time: u64,
     pub width: i32,
@@ -28,6 +32,7 @@ pub struct RGBxFrame {
     pub data: Vec<u8>,
 }
 
+#[derive(Debug, Clone)]
 pub struct XBGRFrame {
     pub display_time: u64,
     pub width: i32,
@@ -35,12 +40,15 @@ pub struct XBGRFrame {
     pub data: Vec<u8>,
 }
 
+#[derive(Debug, Clone)]
 pub struct BGRxFrame {
     pub display_time: u64,
     pub width: i32,
     pub height: i32,
     pub data: Vec<u8>,
 }
+
+#[derive(Debug, Clone)]
 pub struct BGRFrame {
     pub display_time: u64,
     pub width: i32,
@@ -48,6 +56,7 @@ pub struct BGRFrame {
     pub data: Vec<u8>,
 }
 
+#[derive(Debug, Clone)]
 pub struct BGRAFrame {
     pub display_time: u64,
     pub width: i32,
@@ -64,6 +73,7 @@ pub enum FrameType {
     BGRAFrame,
 }
 
+#[derive(Debug, Clone)]
 pub enum Frame {
     YUVFrame(YUVFrame),
     RGB(RGBFrame),


### PR DESCRIPTION
This is essential to let Frames be passed in multiple threads.