### PR TITLE
feat (mac): separate has_permission() and request_permission()

### DIFF
--- a/scap/src/device/display/mac/mod.rs
+++ b/scap/src/device/display/mac/mod.rs
@@ -8,8 +8,11 @@ use sysinfo::System;
 use super::Target;
 
 pub fn has_permission() -> bool {
-    let access = ScreenCaptureAccess::default();
-    access.request()
+    ScreenCaptureAccess::default().preflight()
+}
+
+pub fn request_permission() -> bool {
+    ScreenCaptureAccess::default().request()
 }
 
 pub fn is_supported() -> bool {

--- a/scap/src/device/display/mod.rs
+++ b/scap/src/device/display/mod.rs
@@ -13,15 +13,30 @@ pub struct Target {
     pub id: u32,
 }
 
-/// Checks if the user has permission to capture the screen
+/// Checks if process has permission to capture the screen
 pub fn has_permission() -> bool {
     #[cfg(target_os = "macos")]
     return mac::has_permission();
 
     #[cfg(target_os = "windows")]
     return win::has_permission();
+
     #[cfg(target_os = "linux")]
     return linux::has_permission();
+}
+
+/// Prompts user to grant screen capturing permission to current process
+pub fn request_permission() -> bool {
+    #[cfg(target_os = "macos")]
+    return mac::request_permission();
+
+    // assume windows to be true
+    #[cfg(target_os = "windows")]
+    return true;
+
+    // TODO: check if linux has permission system
+    #[cfg(target_os = "linux")]
+    return true;
 }
 
 /// Checks if scap is supported on the current system

--- a/scap/src/lib.rs
+++ b/scap/src/lib.rs
@@ -8,3 +8,4 @@ pub mod frame;
 pub use device::display::get_targets;
 pub use device::display::has_permission;
 pub use device::display::is_supported;
+pub use device::display::request_permission;

--- a/scap/src/main.rs
+++ b/scap/src/main.rs
@@ -16,14 +16,16 @@ fn main() {
         println!("✅ Platform supported");
     }
 
-    // #2 Check if we have permission to capture the screen
-    let has_permission = scap::has_permission();
-    if !has_permission {
-        println!("❌ Permission not granted");
-        return;
-    } else {
-        println!("✅ Permission granted");
+    // #2 Check if we have permission to capture screen
+    // If we don't, request it.
+    if !scap::has_permission() {
+        println!("❌ Permission not granted. Requesting permission...");
+        if !scap::request_permission() {
+            println!("❌ Permission denied");
+            return;
+        }
     }
+    println!("✅ Permission granted");
 
     // #3 Get recording targets (WIP)
     let targets = scap::get_targets();


### PR DESCRIPTION
Currently the macOS `has_permission()` method will actually stop code execution and prompt the user for granting permissions (which they could choose to decline also) — this led to problems in Helmer Micro where people were unable to grant it permissions even after multiple attempts.

This PR introduces a separate `has_permission()` and `request_permission()` method to try and tackle this.