### PR TITLE
feat: rename CGPoint, CGRect, CGSize → Point, Area, Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you'd like to develop, here's a kickstart guide:
 
 ```rust
 use scap::{
-    capturer::{CGPoint, CGRect, CGSize, Capturer, Options},
+    capturer::{Point, Area, Size, Capturer, Options},
     frame::Frame,
 };
 
@@ -68,9 +68,9 @@ fn main() {
         excluded_targets: None,
         output_type: scap::frame::FrameType::BGRAFrame,
         output_resolution: scap::capturer::Resolution::_720p,
-        source_rect: Some(CGRect {
-            origin: CGPoint { x: 0.0, y: 0.0 },
-            size: CGSize {
+        source_rect: Some(Area {
+            origin: Point { x: 0.0, y: 0.0 },
+            size: Size {
                 width: 2000.0,
                 height: 1000.0,
             },
@@ -123,5 +123,5 @@ The code in this repository is open-sourced under the MIT license. However, it m
 
 This project builds on top of the fabulous work done by [@svtlabs](https://github.com/svtlabs) and [@NiiightmareXD](https://github.com/NiiightmareXD).
 
--   [screencapturekit-rs](https://github.com/svtlabs/screencapturekit-rs): Rust bindings for Apple's ScreencaptureKit API.
--   [windows-capture](https://github.com/NiiightmareXD/windows-capture): Rust library for Windows.Graphics.Capture.
+- [screencapturekit-rs](https://github.com/svtlabs/screencapturekit-rs): Rust bindings for Apple's ScreencaptureKit API.
+- [windows-capture](https://github.com/NiiightmareXD/windows-capture): Rust library for Windows.Graphics.Capture.

--- a/scap/src/capturer/engine/mac/mod.rs
+++ b/scap/src/capturer/engine/mac/mod.rs
@@ -41,10 +41,6 @@ use core_video_sys::{
     CVPixelBufferLockBaseAddress, CVPixelBufferRef, CVPixelBufferUnlockBaseAddress,
 };
 
-// use core_video_sys::{
-//      CVPixelBufferGetHeightOfPlane, CVPixelBufferGetPixelFormatType, CVPixelBufferGetWidthOfPlane,
-// }
-
 struct ErrorHandler;
 impl StreamErrorHandler for ErrorHandler {
     fn on_error(&self) {
@@ -101,10 +97,9 @@ impl StreamOutput for Capturer {
 }
 
 pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> SCStream {
+    // TODO: identify targets to capture using options.targets
+    // scap currently only captures the main display
     let display = display::get_main_display();
-    // let display_id = display.display_id;
-
-    // let scale = display::get_scale_factor(display_id) as u32;
 
     let sc_shareable_content = SCShareableContent::current();
     let excluded_windows = sc_shareable_content
@@ -153,42 +148,6 @@ pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> SCStream {
 
     stream
 }
-
-// pub fn ycbcr_to_rgb(
-//     y_data: &[u8],
-//     cbcr_data: &[u8],
-//     width: usize,
-//     height: usize,
-//     stride: usize,
-// ) -> Vec<u8> {
-//     let mut rgb_data = Vec::with_capacity(width * height * 3);
-//     let row = width + stride;
-
-//     for h in 0..height {
-//         for w in 0..width {
-//             let y_idx = h * row + w;
-//             let uv_idx = (h / 2) * row + w - w % 2;
-
-//             // let y = y_data[y_idx] as f32;
-//             // let cb = cbcr_data[uv_idx] as f32 - 128.0;
-//             // let cr = cbcr_data[uv_idx + 1] as f32 - 128.0;
-
-//             // NOTE: The following values adjust for contrast and range
-//             let y = (y_data[y_idx] as f32 - 16.0) * (255.0 / (235.0 - 16.0));
-//             let cb = (cbcr_data[uv_idx] as f32 - 16.0) * (255.0 / (240.0 - 16.0)) - 128.0;
-//             let cr = (cbcr_data[uv_idx + 1] as f32 - 16.0) * (255.0 / (240.0 - 16.0)) - 128.0;
-
-//             let r = (y + 1.402 * cr).max(0.0).min(255.0) as u8;
-//             let g = (y - 0.344136 * cb - 0.714136 * cr).max(0.0).min(255.0) as u8;
-//             let b = (y + 1.772 * cb).max(0.0).min(255.0) as u8;
-
-//             rgb_data.push(r);
-//             rgb_data.push(g);
-//             rgb_data.push(b);
-//         }
-//     }
-//     rgb_data
-// }
 
 pub unsafe fn create_yuv_frame(sample_buffer: CMSampleBuffer) -> Option<YUVFrame> {
     // Check that the frame status is complete

--- a/scap/src/capturer/engine/mac/mod.rs
+++ b/scap/src/capturer/engine/mac/mod.rs
@@ -37,10 +37,13 @@ use apple_sys::{
 use core_graphics::display::{CFArrayGetCount, CFArrayGetValueAtIndex, CFArrayRef};
 use core_video_sys::{
     CVPixelBufferGetBaseAddress, CVPixelBufferGetBaseAddressOfPlane, CVPixelBufferGetBytesPerRow,
-    CVPixelBufferGetBytesPerRowOfPlane, CVPixelBufferGetHeight, CVPixelBufferGetHeightOfPlane,
-    CVPixelBufferGetPixelFormatType, CVPixelBufferGetWidth, CVPixelBufferGetWidthOfPlane,
+    CVPixelBufferGetBytesPerRowOfPlane, CVPixelBufferGetHeight, CVPixelBufferGetWidth,
     CVPixelBufferLockBaseAddress, CVPixelBufferRef, CVPixelBufferUnlockBaseAddress,
 };
+
+// use core_video_sys::{
+//      CVPixelBufferGetHeightOfPlane, CVPixelBufferGetPixelFormatType, CVPixelBufferGetWidthOfPlane,
+// }
 
 struct ErrorHandler;
 impl StreamErrorHandler for ErrorHandler {
@@ -86,9 +89,6 @@ impl StreamOutput for Capturer {
                                 let bgraframe = create_bgra_frame(sample).unwrap();
                                 frame = Frame::BGRA(bgraframe);
                             }
-                            _ => {
-                                panic!("Unimplemented Output format");
-                            }
                         }
                         self.tx.send(frame).unwrap_or(());
                     },
@@ -102,9 +102,9 @@ impl StreamOutput for Capturer {
 
 pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> SCStream {
     let display = display::get_main_display();
-    let display_id = display.display_id;
+    // let display_id = display.display_id;
 
-    let scale = display::get_scale_factor(display_id) as u32;
+    // let scale = display::get_scale_factor(display_id) as u32;
 
     let sc_shareable_content = SCShareableContent::current();
     let excluded_windows = sc_shareable_content
@@ -154,41 +154,41 @@ pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> SCStream {
     stream
 }
 
-pub fn ycbcr_to_rgb(
-    y_data: &[u8],
-    cbcr_data: &[u8],
-    width: usize,
-    height: usize,
-    stride: usize,
-) -> Vec<u8> {
-    let mut rgb_data = Vec::with_capacity(width * height * 3);
-    let row = width + stride;
+// pub fn ycbcr_to_rgb(
+//     y_data: &[u8],
+//     cbcr_data: &[u8],
+//     width: usize,
+//     height: usize,
+//     stride: usize,
+// ) -> Vec<u8> {
+//     let mut rgb_data = Vec::with_capacity(width * height * 3);
+//     let row = width + stride;
 
-    for h in 0..height {
-        for w in 0..width {
-            let y_idx = h * row + w;
-            let uv_idx = (h / 2) * row + w - w % 2;
+//     for h in 0..height {
+//         for w in 0..width {
+//             let y_idx = h * row + w;
+//             let uv_idx = (h / 2) * row + w - w % 2;
 
-            // let y = y_data[y_idx] as f32;
-            // let cb = cbcr_data[uv_idx] as f32 - 128.0;
-            // let cr = cbcr_data[uv_idx + 1] as f32 - 128.0;
+//             // let y = y_data[y_idx] as f32;
+//             // let cb = cbcr_data[uv_idx] as f32 - 128.0;
+//             // let cr = cbcr_data[uv_idx + 1] as f32 - 128.0;
 
-            // NOTE: The following values adjust for contrast and range
-            let y = (y_data[y_idx] as f32 - 16.0) * (255.0 / (235.0 - 16.0));
-            let cb = (cbcr_data[uv_idx] as f32 - 16.0) * (255.0 / (240.0 - 16.0)) - 128.0;
-            let cr = (cbcr_data[uv_idx + 1] as f32 - 16.0) * (255.0 / (240.0 - 16.0)) - 128.0;
+//             // NOTE: The following values adjust for contrast and range
+//             let y = (y_data[y_idx] as f32 - 16.0) * (255.0 / (235.0 - 16.0));
+//             let cb = (cbcr_data[uv_idx] as f32 - 16.0) * (255.0 / (240.0 - 16.0)) - 128.0;
+//             let cr = (cbcr_data[uv_idx + 1] as f32 - 16.0) * (255.0 / (240.0 - 16.0)) - 128.0;
 
-            let r = (y + 1.402 * cr).max(0.0).min(255.0) as u8;
-            let g = (y - 0.344136 * cb - 0.714136 * cr).max(0.0).min(255.0) as u8;
-            let b = (y + 1.772 * cb).max(0.0).min(255.0) as u8;
+//             let r = (y + 1.402 * cr).max(0.0).min(255.0) as u8;
+//             let g = (y - 0.344136 * cb - 0.714136 * cr).max(0.0).min(255.0) as u8;
+//             let b = (y + 1.772 * cb).max(0.0).min(255.0) as u8;
 
-            rgb_data.push(r);
-            rgb_data.push(g);
-            rgb_data.push(b);
-        }
-    }
-    rgb_data
-}
+//             rgb_data.push(r);
+//             rgb_data.push(g);
+//             rgb_data.push(b);
+//         }
+//     }
+//     rgb_data
+// }
 
 pub unsafe fn create_yuv_frame(sample_buffer: CMSampleBuffer) -> Option<YUVFrame> {
     // Check that the frame status is complete
@@ -315,7 +315,7 @@ pub unsafe fn create_bgra_frame(sample_buffer: CMSampleBuffer) -> Option<BGRAFra
 
     let mut data: Vec<u8> = vec![];
     for i in 0..height {
-        let start = (base_address as *mut u8).wrapping_add((i * bytes_per_row));
+        let start = (base_address as *mut u8).wrapping_add(i * bytes_per_row);
         data.extend_from_slice(slice::from_raw_parts(start, 4 * width));
     }
 

--- a/scap/src/capturer/engine/mod.rs
+++ b/scap/src/capturer/engine/mod.rs
@@ -58,7 +58,7 @@ impl Engine {
         #[cfg(target_os = "macos")]
         {
             // self.mac.add_output(Capturer::new(tx));
-            self.mac.start_capture();
+            self.mac.start_capture().expect("Failed to start capture");
         }
 
         #[cfg(target_os = "windows")]
@@ -75,7 +75,7 @@ impl Engine {
     pub fn stop(&mut self) {
         #[cfg(target_os = "macos")]
         {
-            self.mac.stop_capture();
+            self.mac.stop_capture().expect("Failed to stop capture");
         }
 
         #[cfg(target_os = "windows")]

--- a/scap/src/capturer/engine/win/mod.rs
+++ b/scap/src/capturer/engine/win/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    capturer::{CGPoint, CGRect, CGSize, Options, Resolution},
+    capturer::{Area, Options, Point, Resolution, Size},
     device::display::{self},
     frame::{BGRAFrame, Frame, FrameType},
 };
@@ -18,7 +18,7 @@ use windows_capture::{
 #[derive(Debug)]
 struct Capturer {
     pub tx: mpsc::Sender<Frame>,
-    pub crop: Option<CGRect>,
+    pub crop: Option<Area>,
 }
 
 impl Capturer {
@@ -26,7 +26,7 @@ impl Capturer {
         Capturer { tx, crop: None }
     }
 
-    pub fn with_crop(mut self, crop: Option<CGRect>) -> Self {
+    pub fn with_crop(mut self, crop: Option<Area>) -> Self {
         self.crop = crop;
         self
     }
@@ -133,7 +133,7 @@ impl WinStream {
 #[derive(Clone, Debug)]
 struct FlagStruct {
     pub tx: mpsc::Sender<Frame>,
-    pub crop: Option<CGRect>,
+    pub crop: Option<Area>,
 }
 
 pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> WinStream {
@@ -187,7 +187,7 @@ pub fn get_output_frame_size(options: &Options) -> [u32; 2] {
     [output_width, output_height]
 }
 
-pub fn get_source_rect(options: &Options) -> CGRect {
+pub fn get_source_rect(options: &Options) -> Area {
     let display = display::get_main_display();
     let width_result = display.width();
     let height_result = display.height();
@@ -213,20 +213,20 @@ pub fn get_source_rect(options: &Options) -> CGRect {
             } else {
                 (val.size.height as i64) + 1
             };
-            CGRect {
-                origin: CGPoint {
+            Area {
+                origin: Point {
                     x: val.origin.x,
                     y: val.origin.y,
                 },
-                size: CGSize {
+                size: Size {
                     width: input_width as f64,
                     height: input_height as f64,
                 },
             }
         }
-        None => CGRect {
-            origin: CGPoint { x: 0.0, y: 0.0 },
-            size: CGSize {
+        None => Area {
+            origin: Point { x: 0.0, y: 0.0 },
+            size: Size {
                 width: width as f64,
                 height: height as f64,
             },

--- a/scap/src/capturer/mod.rs
+++ b/scap/src/capturer/mod.rs
@@ -37,20 +37,20 @@ impl Resolution {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct CGPoint {
+pub struct Point {
     pub x: f64,
     pub y: f64,
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct CGSize {
+pub struct Size {
     pub width: f64,
     pub height: f64,
 }
 #[derive(Debug, Default, Clone)]
-pub struct CGRect {
-    pub origin: CGPoint,
-    pub size: CGSize,
+pub struct Area {
+    pub origin: Point,
+    pub size: Size,
 }
 
 /// Options passed to the screen capturer
@@ -67,7 +67,7 @@ pub struct Options {
     pub excluded_windows: Option<Vec<String>>,
     pub output_type: FrameType,
     pub output_resolution: Resolution,
-    pub source_rect: Option<CGRect>,
+    pub source_rect: Option<Area>,
 }
 
 /// Screen capturer class

--- a/scap/src/main.rs
+++ b/scap/src/main.rs
@@ -2,7 +2,7 @@
 // Refer to the lib.rs file for the actual implementation
 
 use scap::{
-    capturer::{CGPoint, CGRect, CGSize, Capturer, Options},
+    capturer::{Area, Capturer, Options, Point, Size},
     frame::Frame,
 };
 
@@ -40,9 +40,9 @@ fn main() {
         excluded_targets: None,
         output_type: scap::frame::FrameType::BGRAFrame,
         output_resolution: scap::capturer::Resolution::_720p,
-        source_rect: Some(CGRect {
-            origin: CGPoint { x: 0.0, y: 0.0 },
-            size: CGSize {
+        source_rect: Some(Area {
+            origin: Point { x: 0.0, y: 0.0 },
+            size: Size {
                 width: 2000.0,
                 height: 1000.0,
             },
@@ -105,7 +105,7 @@ fn main() {
                 );
             }
             Frame::BGRA(frame) => {
-                if (start_time == 0) {
+                if start_time == 0 {
                     start_time = frame.display_time;
                 }
                 println!(


### PR DESCRIPTION
Closes #60 and also actions all warnings from rust compiler when running `cargo run` and `cargo check`.