### PR TITLE
chore: use helmer maintained forks for apple-sys and core-graphics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,18 +56,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
-name = "apple-bindgen"
+name = "apple-bindgen-helmer-fork"
 version = "0.2.0"
-source = "git+https://github.com/Pranav2612000/apple-sys/?branch=main#11f7ad17d5d015e9c6570c85e5abfc5e9d065bd1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9717d1bd9d5fb13ef1de642273bac67e654664b69e99a65b7738cc9cbf0ca5e4"
 dependencies = [
  "apple-sdk",
  "bindgen",
+ "clap",
  "derive_more",
  "regex",
  "serde",
@@ -87,11 +138,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "apple-sys"
+name = "apple-sys-helmer-fork"
 version = "0.2.0"
-source = "git+https://github.com/Pranav2612000/apple-sys/?branch=main#11f7ad17d5d015e9c6570c85e5abfc5e9d065bd1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03b84426ef7620d5554496dd85d4f80ab3d348cbc929d4ec8ea0ed6ddf6b075"
 dependencies = [
- "apple-bindgen",
+ "apple-bindgen-helmer-fork",
  "apple-sdk",
  "objc",
 ]
@@ -234,10 +286,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.64",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "combine"
@@ -730,6 +828,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1415,7 +1519,7 @@ dependencies = [
 name = "scap"
 version = "0.0.4"
 dependencies = [
- "apple-sys",
+ "apple-sys-helmer-fork",
  "bytes",
  "core-graphics-helmer-fork",
  "cpal",
@@ -1543,6 +1647,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1770,6 +1880,12 @@ name = "unicode-width"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,10 +275,11 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
-source = "git+https://github.com/helmerapp/core-foundation-rs?branch=main#3e70cbced9fd36372047a049794ba652b139ea91"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "core-foundation-sys 0.8.6 (git+https://github.com/helmerapp/core-foundation-rs?branch=main)",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -289,14 +290,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "git+https://github.com/helmerapp/core-foundation-rs?branch=main#3e70cbced9fd36372047a049794ba652b139ea91"
-
-[[package]]
-name = "core-graphics"
+name = "core-graphics-helmer-fork"
 version = "0.24.0"
-source = "git+https://github.com/helmerapp/core-foundation-rs?branch=main#3e70cbced9fd36372047a049794ba652b139ea91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32eb7c354ae9f6d437a6039099ce7ecd049337a8109b23d73e48e8ffba8e9cd5"
 dependencies = [
  "bitflags 2.5.0",
  "core-foundation",
@@ -307,10 +304,11 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.2.0"
-source = "git+https://github.com/helmerapp/core-foundation-rs?branch=main#3e70cbced9fd36372047a049794ba652b139ea91"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 1.3.2",
  "core-foundation",
  "libc",
 ]
@@ -322,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation-sys 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys",
  "coreaudio-sys",
 ]
 
@@ -342,7 +340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
 dependencies = [
  "alsa",
- "core-foundation-sys 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
@@ -1419,7 +1417,7 @@ version = "0.0.4"
 dependencies = [
  "apple-sys",
  "bytes",
- "core-graphics",
+ "core-graphics-helmer-fork",
  "cpal",
  "dbus",
  "hound",
@@ -1575,7 +1573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
 dependencies = [
  "cfg-if",
- "core-foundation-sys 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys",
  "libc",
  "ntapi",
  "once_cell",
@@ -1603,7 +1601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271450eb289cb4d8d0720c6ce70c72c8c858c93dd61fc625881616752e6b98f6"
 dependencies = [
  "cfg-if",
- "core-foundation-sys 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys",
  "libc",
  "objc",
 ]

--- a/scap/Cargo.toml
+++ b/scap/Cargo.toml
@@ -34,7 +34,7 @@ tao-core-video-sys = "0.2.0"
 core-graphics-helmer-fork = "0.24.0"
 screencapturekit = "0.2.8"
 screencapturekit-sys = "0.2.8"
-apple-sys = { git = "https://github.com/Pranav2612000/apple-sys/", branch = "main", features = ["CoreMedia", "ScreenCaptureKit"] }
+apple-sys-helmer-fork = { version = "0.2.0", features = ["CoreMedia", "ScreenCaptureKit"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 pipewire = "0.8.0"

--- a/scap/Cargo.toml
+++ b/scap/Cargo.toml
@@ -31,7 +31,7 @@ windows = { version = "0.52", features = [
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tao-core-video-sys = "0.2.0"
-core-graphics = { git= "https://github.com/helmerapp/core-foundation-rs", branch = "main" }
+core-graphics-helmer-fork = "0.24.0"
 screencapturekit = "0.2.8"
 screencapturekit-sys = "0.2.8"
 apple-sys = { git = "https://github.com/Pranav2612000/apple-sys/", branch = "main", features = ["CoreMedia", "ScreenCaptureKit"] }

--- a/scap/src/capturer/engine/mac/mod.rs
+++ b/scap/src/capturer/engine/mac/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     capturer::Resolution,
     device::display::{self},
 };
-use apple_sys::{
+use apple_sys_helmer_fork::{
     CoreMedia::{
         CFDictionaryGetValue, CFDictionaryRef, CFNumberGetValue, CFNumberType_kCFNumberSInt64Type,
         CFTypeRef,

--- a/scap/src/capturer/engine/mac/mod.rs
+++ b/scap/src/capturer/engine/mac/mod.rs
@@ -34,7 +34,7 @@ use apple_sys::{
     },
     ScreenCaptureKit::{SCFrameStatus_SCFrameStatusComplete, SCStreamFrameInfoStatus},
 };
-use core_graphics::display::{CFArrayGetCount, CFArrayGetValueAtIndex, CFArrayRef};
+use core_graphics_helmer_fork::display::{CFArrayGetCount, CFArrayGetValueAtIndex, CFArrayRef};
 use core_video_sys::{
     CVPixelBufferGetBaseAddress, CVPixelBufferGetBaseAddressOfPlane, CVPixelBufferGetBytesPerRow,
     CVPixelBufferGetBytesPerRowOfPlane, CVPixelBufferGetHeight, CVPixelBufferGetWidth,

--- a/scap/src/device/display/mac/mod.rs
+++ b/scap/src/device/display/mac/mod.rs
@@ -1,4 +1,4 @@
-use core_graphics::{
+use core_graphics_helmer_fork::{
     access::ScreenCaptureAccess,
     display::{CGDirectDisplayID, CGDisplay, CGMainDisplayID},
 };


### PR DESCRIPTION
This will allow us to release the latest version of scap.