### PR TITLE
feat: macos targets scale factor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,12 +281,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,8 +1113,10 @@ name = "scap"
 version = "0.0.5"
 dependencies = [
  "apple-sys-helmer-fork",
+ "cocoa",
  "core-graphics-helmer-fork",
  "dbus",
+ "objc",
  "pipewire",
  "rand",
  "screencapturekit",

--- a/src/capturer/engine/mac/mod.rs
+++ b/src/capturer/engine/mac/mod.rs
@@ -135,11 +135,12 @@ pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> SCStream {
 }
 
 pub fn get_output_frame_size(options: &Options) -> [u32; 2] {
-    // TODO: this should be based on display from options.target, not main one
-    let display = targets::get_main_display();
-    let display_id = display.id;
-    let scale_factor = targets::get_scale_factor(display_id);
+    let target = options
+        .target
+        .clone()
+        .unwrap_or_else(|| Target::Display(targets::get_main_display()));
 
+    let scale_factor = targets::get_scale_factor(&target);
     let source_rect = get_crop_area(options);
 
     // Calculate the output height & width based on the required resolution

--- a/src/targets/mac/mod.rs
+++ b/src/targets/mac/mod.rs
@@ -1,13 +1,12 @@
-use cocoa::appkit::NSScreen;
+use cocoa::appkit::{NSApp, NSScreen};
 use cocoa::base::{id, nil};
-use cocoa::foundation::NSString;
-use core_graphics_helmer_fork::display::{CGDirectDisplayID, CGMainDisplayID};
+use cocoa::foundation::{NSString, NSUInteger};
+use core_graphics_helmer_fork::display::{CGDirectDisplayID, CGDisplay, CGMainDisplayID};
+use core_graphics_helmer_fork::window::CGWindowID;
 use objc::{msg_send, sel, sel_impl};
 use screencapturekit::sc_shareable_content::SCShareableContent;
 
 use super::{Display, Target};
-
-pub use core_graphics_helmer_fork::display::CGDisplay;
 
 fn get_display_name(display_id: CGDirectDisplayID) -> String {
     unsafe {
@@ -59,8 +58,13 @@ pub fn get_targets() -> Vec<Target> {
         if window.title.is_some() {
             let id = window.window_id;
             let title = window.title.expect("Window title not found");
+            let raw_handle: CGWindowID = id;
 
-            let target = Target::Window(super::Window { id, title });
+            let target = Target::Window(super::Window {
+                id,
+                title,
+                raw_handle,
+            });
             targets.push(target);
         }
     }
@@ -79,7 +83,18 @@ pub fn get_main_display() -> Display {
     }
 }
 
-pub fn get_scale_factor(display_id: CGDirectDisplayID) -> f64 {
-    let mode = CGDisplay::new(display_id).display_mode().unwrap();
-    (mode.pixel_width() / mode.width()) as f64
+pub fn get_scale_factor(target: &Target) -> f64 {
+    match target {
+        Target::Window(window) => unsafe {
+            let cg_win_id = window.raw_handle;
+            let ns_app: id = NSApp();
+            let ns_window: id = msg_send![ns_app, windowWithWindowNumber: cg_win_id as NSUInteger];
+            let scale_factor: f64 = msg_send![ns_window, backingScaleFactor];
+            scale_factor
+        },
+        Target::Display(display) => {
+            let mode = display.raw_handle.display_mode().unwrap();
+            (mode.pixel_width() / mode.width()) as f64
+        }
+    }
 }

--- a/src/targets/mod.rs
+++ b/src/targets/mod.rs
@@ -14,6 +14,9 @@ pub struct Window {
 
     #[cfg(target_os = "windows")]
     pub raw_handle: windows::Win32::Foundation::HWND,
+
+    #[cfg(target_os = "macos")]
+    pub raw_handle: core_graphics_helmer_fork::window::CGWindowID,
 }
 
 #[derive(Debug, Clone)]
@@ -46,12 +49,12 @@ pub fn get_targets() -> Vec<Target> {
     return linux::get_targets();
 }
 
-pub fn get_scale_factor(display_id: u32) -> f64 {
+pub fn get_scale_factor(target: &Target) -> f64 {
     #[cfg(target_os = "macos")]
-    return mac::get_scale_factor(display_id);
+    return mac::get_scale_factor(target);
 
     #[cfg(target_os = "windows")]
-    return win::get_scale_factor(display_id);
+    return win::get_scale_factor(target);
 
     #[cfg(target_os = "linux")]
     return 1;


### PR DESCRIPTION
Previously `scale_factor` was only calculated on a Display level. This PR updates the function to also work on Window targets as well.

This is the macOS equivalent of PR #85 (for Windows OS)

It also adds a `CGWindowID` so people can get the underlying raw_window_handle from there.