### PR TITLE
feat: correct crop_area for specific targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ windows = { version = "0.52", features = [
 	"Graphics_Capture",
 	"Win32_Foundation",
 	"Win32_Graphics_Gdi",
-	"Win32_UI_HiDpi"
+	"Win32_UI_HiDpi",
+	"Win32_UI_WindowsAndMessaging"
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/capturer/engine/mac/mod.rs
+++ b/src/capturer/engine/mac/mod.rs
@@ -193,10 +193,12 @@ pub fn get_output_frame_size(options: &Options) -> [u32; 2] {
 }
 
 pub fn get_crop_area(options: &Options) -> CGRect {
-    // TODO: this should be based on options.target, not main display
-    let display = targets::get_main_display();
-    let width = display.raw_handle.pixels_wide();
-    let height = display.raw_handle.pixels_high();
+    let target = options
+        .target
+        .clone()
+        .unwrap_or_else(|| Target::Display(targets::get_main_display()));
+
+    let (width, height) = targets::get_target_dimensions(&target);
 
     options
         .crop_area

--- a/src/capturer/engine/win/mod.rs
+++ b/src/capturer/engine/win/mod.rs
@@ -217,15 +217,12 @@ pub fn get_output_frame_size(options: &Options) -> [u32; 2] {
 }
 
 pub fn get_crop_area(options: &Options) -> Area {
-    // TODO: this should be based on options.target, not main display
-    let display = targets::get_main_display();
-    let display_raw = WCMonitor::from_raw_hmonitor(display.raw_handle.0);
+    let target = options
+        .target
+        .clone()
+        .unwrap_or_else(|| Target::Display(targets::get_main_display()));
 
-    let width_result = display_raw.width();
-    let height_result = display_raw.height();
-
-    let width = width_result.unwrap_or(0);
-    let height = height_result.unwrap_or(0);
+    let (width, height) = targets::get_target_dimensions(&target);
 
     options
         .crop_area

--- a/src/targets/mac/mod.rs
+++ b/src/targets/mac/mod.rs
@@ -1,6 +1,6 @@
 use cocoa::appkit::{NSApp, NSScreen};
 use cocoa::base::{id, nil};
-use cocoa::foundation::{NSString, NSUInteger};
+use cocoa::foundation::{NSRect, NSString, NSUInteger};
 use core_graphics_helmer_fork::display::{CGDirectDisplayID, CGDisplay, CGMainDisplayID};
 use core_graphics_helmer_fork::window::CGWindowID;
 use objc::{msg_send, sel, sel_impl};
@@ -95,6 +95,22 @@ pub fn get_scale_factor(target: &Target) -> f64 {
         Target::Display(display) => {
             let mode = display.raw_handle.display_mode().unwrap();
             (mode.pixel_width() / mode.width()) as f64
+        }
+    }
+}
+
+pub fn get_target_dimensions(target: &Target) -> (u64, u64) {
+    match target {
+        Target::Window(window) => unsafe {
+            let cg_win_id = window.raw_handle;
+            let ns_app: id = NSApp();
+            let ns_window: id = msg_send![ns_app, windowWithWindowNumber: cg_win_id as NSUInteger];
+            let frame: NSRect = msg_send![ns_window, frame];
+            (frame.size.width as u64, frame.size.height as u64)
+        },
+        Target::Display(display) => {
+            let mode = display.raw_handle.display_mode().unwrap();
+            (mode.width(), mode.height())
         }
     }
 }

--- a/src/targets/mod.rs
+++ b/src/targets/mod.rs
@@ -70,3 +70,14 @@ pub fn get_main_display() -> Display {
     // #[cfg(target_os = "linux")]
     // return linux::get_main_display();
 }
+
+pub fn get_target_dimensions(target: &Target) -> (u64, u64) {
+    #[cfg(target_os = "macos")]
+    return mac::get_target_dimensions(target);
+
+    #[cfg(target_os = "windows")]
+    return win::get_target_dimensions(target);
+
+    // #[cfg(target_os = "linux")]
+    // return linux::get_target_dimensions(target);
+}


### PR DESCRIPTION
The crop_area was based on primary display. With this PR it is now applied relative to the target specified.

Changes:
1. added a `get_target_dimensions` funcition on windows and mac
2. use this function to compare against crop_area and return that correctly