### PR TITLE
Fix restart on pipewire capturer

### DIFF
--- a/src/capturer/engine/linux/mod.rs
+++ b/src/capturer/engine/linux/mod.rs
@@ -375,6 +375,7 @@ impl LinuxCapturer {
                 eprintln!("Error occured capturing: {e}");
             }
         }
+        CAPTURER_STATE.store(0, std::sync::atomic::Ordering::Relaxed);
     }
 }
 

--- a/src/capturer/engine/linux/mod.rs
+++ b/src/capturer/engine/linux/mod.rs
@@ -376,6 +376,7 @@ impl LinuxCapturer {
             }
         }
         CAPTURER_STATE.store(0, std::sync::atomic::Ordering::Relaxed);
+        STREAM_STATE_CHANGED_TO_ERROR.store(false, std::sync::atomic::Ordering::Relaxed);
     }
 }
 


### PR DESCRIPTION
https://github.com/helmerapp/scap/issues/100

As far as I understand, the capturer state should return to 0 after the capturer has fully shut down. Locally, this seems to fix my issue.