### PR TITLE
raw pixel buffers

### DIFF
--- a/src/capturer/engine/mac/apple_sys.rs
+++ b/src/capturer/engine/mac/apple_sys.rs
@@ -1,3 +1,5 @@
+#![allow(non_upper_case_globals)]
+
 pub use screencapturekit_sys::os_types::base::*;
 
 #[repr(C)]

--- a/src/capturer/engine/mac/pixel_buffer.rs
+++ b/src/capturer/engine/mac/pixel_buffer.rs
@@ -2,9 +2,8 @@ use core::slice;
 use core_video_sys::{
     CVPixelBufferGetBaseAddress, CVPixelBufferGetBaseAddressOfPlane, CVPixelBufferGetBytesPerRow,
     CVPixelBufferGetBytesPerRowOfPlane, CVPixelBufferGetHeight, CVPixelBufferGetHeightOfPlane,
-    CVPixelBufferGetPixelFormatType, CVPixelBufferGetPlaneCount, CVPixelBufferGetWidth,
-    CVPixelBufferGetWidthOfPlane, CVPixelBufferLockBaseAddress, CVPixelBufferRef,
-    CVPixelBufferUnlockBaseAddress,
+    CVPixelBufferGetPlaneCount, CVPixelBufferGetWidth, CVPixelBufferGetWidthOfPlane,
+    CVPixelBufferLockBaseAddress, CVPixelBufferRef, CVPixelBufferUnlockBaseAddress,
 };
 use screencapturekit::{cm_sample_buffer::CMSampleBuffer, sc_types::SCFrameStatus};
 use screencapturekit_sys::cm_sample_buffer_ref::CMSampleBufferGetImageBuffer;

--- a/src/capturer/engine/mac/pixel_buffer.rs
+++ b/src/capturer/engine/mac/pixel_buffer.rs
@@ -170,9 +170,9 @@ impl RawCapturer<'_> {
 
 pub unsafe fn sample_buffer_to_pixel_buffer(sample_buffer: &CMSampleBuffer) -> CVPixelBufferRef {
     let buffer_ref = &(*sample_buffer.sys_ref);
-    let pixel_buffer = CMSampleBufferGetImageBuffer(buffer_ref) as CVPixelBufferRef;
+    
 
-    pixel_buffer
+    CMSampleBufferGetImageBuffer(buffer_ref) as CVPixelBufferRef
 }
 
 pub unsafe fn pixel_buffer_bounds(pixel_buffer: CVPixelBufferRef) -> (usize, usize) {

--- a/src/capturer/engine/mac/pixel_buffer.rs
+++ b/src/capturer/engine/mac/pixel_buffer.rs
@@ -1,0 +1,192 @@
+use core::slice;
+use core_video_sys::{
+    CVPixelBufferGetBaseAddress, CVPixelBufferGetBaseAddressOfPlane, CVPixelBufferGetBytesPerRow,
+    CVPixelBufferGetBytesPerRowOfPlane, CVPixelBufferGetHeight, CVPixelBufferGetHeightOfPlane,
+    CVPixelBufferGetPixelFormatType, CVPixelBufferGetPlaneCount, CVPixelBufferGetWidth,
+    CVPixelBufferGetWidthOfPlane, CVPixelBufferLockBaseAddress, CVPixelBufferRef,
+    CVPixelBufferUnlockBaseAddress,
+};
+use screencapturekit::{cm_sample_buffer::CMSampleBuffer, sc_types::SCFrameStatus};
+use screencapturekit_sys::cm_sample_buffer_ref::CMSampleBufferGetImageBuffer;
+use std::{ops::Deref, sync::mpsc};
+
+use crate::capturer::{engine::ChannelItem, RawCapturer};
+
+pub struct PixelBuffer {
+    display_time: u64,
+    width: usize,
+    height: usize,
+    bytes_per_row: usize,
+    buffer: CMSampleBuffer,
+}
+
+impl PixelBuffer {
+    pub fn display_time(&self) -> u64 {
+        self.display_time
+    }
+
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    pub fn buffer(&self) -> &CMSampleBuffer {
+        &self.buffer
+    }
+
+    pub fn bytes_per_row(&self) -> usize {
+        self.bytes_per_row
+    }
+
+    pub fn data(&self) -> PixelBufferData {
+        unsafe {
+            let pixel_buffer = sample_buffer_to_pixel_buffer(&self.buffer);
+
+            CVPixelBufferLockBaseAddress(pixel_buffer, 0);
+
+            let base_address = CVPixelBufferGetBaseAddress(pixel_buffer);
+
+            PixelBufferData {
+                buffer: pixel_buffer,
+                data: slice::from_raw_parts(
+                    base_address as *mut _,
+                    self.bytes_per_row * self.height,
+                ),
+            }
+        }
+    }
+
+    pub fn planes(&self) -> Vec<Plane> {
+        unsafe {
+            let pixel_buffer = sample_buffer_to_pixel_buffer(&self.buffer);
+            let count = CVPixelBufferGetPlaneCount(pixel_buffer);
+
+            CVPixelBufferLockBaseAddress(pixel_buffer, 0);
+
+            (0..count)
+                .map(|i| Plane {
+                    buffer: pixel_buffer,
+                    width: CVPixelBufferGetWidthOfPlane(pixel_buffer, i),
+                    height: CVPixelBufferGetHeightOfPlane(pixel_buffer, i),
+                    bytes_per_row: CVPixelBufferGetBytesPerRowOfPlane(pixel_buffer, i),
+                    index: i,
+                })
+                .collect()
+        }
+    }
+
+    pub(crate) fn new(item: ChannelItem) -> Option<Self> {
+        unsafe {
+            let display_time = pixel_buffer_display_time(&item.0);
+            let pixel_buffer = sample_buffer_to_pixel_buffer(&item.0);
+            let (width, height) = pixel_buffer_bounds(pixel_buffer);
+
+            match item.0.frame_status {
+                SCFrameStatus::Complete | SCFrameStatus::Started | SCFrameStatus::Idle => {
+                    Some(Self {
+                        display_time,
+                        width,
+                        height,
+                        bytes_per_row: pixel_buffer_bytes_per_row(pixel_buffer),
+                        buffer: item.0,
+                    })
+                }
+                _ => None,
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Plane {
+    buffer: CVPixelBufferRef,
+    index: usize,
+    width: usize,
+    height: usize,
+    bytes_per_row: usize,
+}
+
+impl Plane {
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    pub fn bytes_per_row(&self) -> usize {
+        self.bytes_per_row
+    }
+
+    pub fn data(&self) -> PixelBufferData {
+        unsafe {
+            CVPixelBufferLockBaseAddress(self.buffer, 0);
+
+            let base_address = CVPixelBufferGetBaseAddressOfPlane(self.buffer, self.index);
+
+            PixelBufferData {
+                buffer: self.buffer,
+                data: slice::from_raw_parts(
+                    base_address as *mut _,
+                    self.bytes_per_row * self.height,
+                ),
+            }
+        }
+    }
+}
+
+pub struct PixelBufferData<'a> {
+    buffer: CVPixelBufferRef,
+    data: &'a [u8],
+}
+
+impl<'a> Deref for PixelBufferData<'a> {
+    type Target = [u8];
+
+    fn deref(&self) -> &'a Self::Target {
+        self.data
+    }
+}
+
+impl<'a> Drop for PixelBufferData<'a> {
+    fn drop(&mut self) {
+        unsafe { CVPixelBufferUnlockBaseAddress(self.buffer, 0) };
+    }
+}
+
+impl RawCapturer<'_> {
+    #[cfg(target_os = "macos")]
+    pub fn get_next_pixel_buffer(&self) -> Result<PixelBuffer, mpsc::RecvError> {
+        loop {
+            if let Some(frame) = PixelBuffer::new(self.capturer.rx.recv()?) {
+                return Ok(frame);
+            }
+        }
+    }
+}
+
+pub unsafe fn sample_buffer_to_pixel_buffer(sample_buffer: &CMSampleBuffer) -> CVPixelBufferRef {
+    let buffer_ref = &(*sample_buffer.sys_ref);
+    let pixel_buffer = CMSampleBufferGetImageBuffer(buffer_ref) as CVPixelBufferRef;
+
+    pixel_buffer
+}
+
+pub unsafe fn pixel_buffer_bounds(pixel_buffer: CVPixelBufferRef) -> (usize, usize) {
+    let width = CVPixelBufferGetWidth(pixel_buffer);
+    let height = CVPixelBufferGetHeight(pixel_buffer);
+
+    (width, height)
+}
+
+pub unsafe fn pixel_buffer_bytes_per_row(pixel_buffer: CVPixelBufferRef) -> usize {
+    CVPixelBufferGetBytesPerRow(pixel_buffer)
+}
+
+pub unsafe fn pixel_buffer_display_time(sample_buffer: &CMSampleBuffer) -> u64 {
+    sample_buffer.sys_ref.get_presentation_timestamp().value as u64
+}

--- a/src/capturer/engine/mac/pixelformat.rs
+++ b/src/capturer/engine/mac/pixelformat.rs
@@ -1,9 +1,7 @@
 use std::{mem, slice};
 
-use screencapturekit::{cm_sample_buffer::CMSampleBuffer, cv_pixel_buffer::CVPixelBuffer};
-use screencapturekit_sys::cm_sample_buffer_ref::{
-    CMSampleBufferGetImageBuffer, CMSampleBufferGetSampleAttachmentsArray,
-};
+use screencapturekit::cm_sample_buffer::CMSampleBuffer;
+use screencapturekit_sys::cm_sample_buffer_ref::CMSampleBufferGetSampleAttachmentsArray;
 
 use super::{
     apple_sys::*,
@@ -61,7 +59,7 @@ pub unsafe fn create_yuv_frame(sample_buffer: CMSampleBuffer) -> Option<YUVFrame
     }
 
     let display_time = get_pts_in_nanoseconds(&sample_buffer);
-    let pixel_buffer = CMSampleBufferGetImageBuffer(buffer_ref) as CVPixelBufferRef;
+    let pixel_buffer = sample_buffer_to_pixel_buffer(&sample_buffer);
 
     CVPixelBufferLockBaseAddress(pixel_buffer, 0);
 

--- a/src/capturer/engine/mod.rs
+++ b/src/capturer/engine/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc;
 
 use super::Options;
-use crate::frame::{Frame, FrameType};
+use crate::frame::Frame;
 
 #[cfg(target_os = "macos")]
 mod mac;
@@ -54,11 +54,11 @@ impl Engine {
     pub fn new(options: &Options, tx: mpsc::Sender<ChannelItem>) -> Engine {
         #[cfg(target_os = "macos")]
         {
-            let mac = mac::create_capturer(&options, tx);
-            return Engine {
+            let mac = mac::create_capturer(options, tx);
+            Engine {
                 mac,
                 options: (*options).clone(),
-            };
+            }
         }
 
         #[cfg(target_os = "windows")]

--- a/src/capturer/mod.rs
+++ b/src/capturer/mod.rs
@@ -1,6 +1,6 @@
 mod engine;
 
-use std::sync::mpsc;
+use std::{error::Error, sync::mpsc};
 
 use engine::ChannelItem;
 
@@ -28,12 +28,12 @@ pub enum Resolution {
 impl Resolution {
     fn value(&self, aspect_ratio: f32) -> [u32; 2] {
         match *self {
-            Resolution::_480p => [640, ((640 as f32) / aspect_ratio).floor() as u32],
-            Resolution::_720p => [1280, ((1280 as f32) / aspect_ratio).floor() as u32],
-            Resolution::_1080p => [1920, ((1920 as f32) / aspect_ratio).floor() as u32],
-            Resolution::_1440p => [2560, ((2560 as f32) / aspect_ratio).floor() as u32],
-            Resolution::_2160p => [3840, ((3840 as f32) / aspect_ratio).floor() as u32],
-            Resolution::_4320p => [7680, ((7680 as f32) / aspect_ratio).floor() as u32],
+            Resolution::_480p => [640, (640_f32 / aspect_ratio).floor() as u32],
+            Resolution::_720p => [1280, (1280_f32 / aspect_ratio).floor() as u32],
+            Resolution::_1080p => [1920, (1920_f32 / aspect_ratio).floor() as u32],
+            Resolution::_1440p => [2560, (2560_f32 / aspect_ratio).floor() as u32],
+            Resolution::_2160p => [3840, (3840_f32 / aspect_ratio).floor() as u32],
+            Resolution::_4320p => [7680, (7680_f32 / aspect_ratio).floor() as u32],
             Resolution::Captured => {
                 panic!(".value should not be called when Resolution type is Captured")
             }
@@ -78,10 +78,24 @@ pub struct Capturer {
     rx: mpsc::Receiver<ChannelItem>,
 }
 
+#[derive(Debug)]
 pub enum CapturerBuildError {
     NotSupported,
     PermissionNotGranted,
 }
+
+impl std::fmt::Display for CapturerBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CapturerBuildError::NotSupported => write!(f, "Screen capturing is not supported"),
+            CapturerBuildError::PermissionNotGranted => {
+                write!(f, "Permission to capture the screen is not granted")
+            }
+        }
+    }
+}
+
+impl Error for CapturerBuildError {}
 
 impl Capturer {
     /// Create a new capturer instance with the provided options

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -101,7 +101,7 @@ pub fn remove_alpha_channel(frame_data: Vec<u8>) -> Vec<u8> {
         dst[2] = src[2];
     }
 
-    return data;
+    data
 }
 
 pub fn convert_bgra_to_rgb(frame_data: Vec<u8>) -> Vec<u8> {
@@ -116,24 +116,24 @@ pub fn convert_bgra_to_rgb(frame_data: Vec<u8>) -> Vec<u8> {
         dst[2] = src[0];
     }
 
-    return data;
+    data
 }
 
 pub fn get_cropped_data(data: Vec<u8>, cur_width: i32, height: i32, width: i32) -> Vec<u8> {
     if data.len() as i32 != height * cur_width * 4 {
-        return data;
+        data
     } else {
         let mut cropped_data: Vec<u8> = vec![0; (4 * height * width).try_into().unwrap()];
         let mut cropped_data_index = 0;
 
-        for i in 0..data.len() {
+        for (i, item) in data.iter().enumerate() {
             let x = i as i32 % (cur_width * 4);
             if x < (width * 4) {
-                cropped_data[cropped_data_index] = data[i];
+                cropped_data[cropped_data_index] = *item;
                 cropped_data_index += 1;
             }
         }
-        return cropped_data;
+        cropped_data
     }
 }
 

--- a/src/utils/mac/mod.rs
+++ b/src/utils/mac/mod.rs
@@ -2,11 +2,11 @@ use core_graphics_helmer_fork::access::ScreenCaptureAccess;
 use sysinfo::System;
 
 pub fn has_permission() -> bool {
-    ScreenCaptureAccess::default().preflight()
+    ScreenCaptureAccess.preflight()
 }
 
 pub fn request_permission() -> bool {
-    ScreenCaptureAccess::default().request()
+    ScreenCaptureAccess.request()
 }
 
 pub fn is_supported() -> bool {


### PR DESCRIPTION
Introduces `capturer.raw()` which returns a `RawCapturer`. On macOS this struct exposes `get_next_pixel_buffer`, which returns a wrapper around the underlying `CMSampleBuffer` with minimal processing after the fact.
We do this to sidestep scap's manual [stride correction](https://github.com/CapSoftware/scap/blob/f63eb09d3b244d49cd675e29b080706886ed52e3/src/capturer/engine/mac/pixelformat.rs#L153-L156) which in most cases is probably useful, but when looking for higher performance when working with a larger video processing pipeline is better suited to be done outside of scap.