### PR TITLE
Fix scap on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scap"
 description = "Modern, high-performance screen capture library for Rust. Cross-platform."
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 rust-version = "1.71"
 license = "MIT"

--- a/src/capturer/engine/win/mod.rs
+++ b/src/capturer/engine/win/mod.rs
@@ -14,6 +14,7 @@ use windows_capture::{
     settings::{ColorFormat, CursorCaptureSettings, DrawBorderSettings, Settings as WCSettings},
     window::Window as WCWindow,
 };
+use windows_capture::capture::Context;
 
 #[derive(Debug)]
 struct Capturer {

--- a/src/capturer/engine/win/mod.rs
+++ b/src/capturer/engine/win/mod.rs
@@ -36,10 +36,10 @@ impl GraphicsCaptureApiHandler for Capturer {
     type Flags = FlagStruct;
     type Error = Box<dyn std::error::Error + Send + Sync>;
 
-    fn new(flag_values: Self::Flags) -> Result<Self, Self::Error> {
+    fn new(context: Context<Self::Flags>) -> Result<Self, Self::Error> {
         Ok(Self {
-            tx: flag_values.tx,
-            crop: flag_values.crop,
+            tx: context.flags.tx,
+            crop: context.flags.crop,
         })
     }
 

--- a/src/capturer/engine/win/mod.rs
+++ b/src/capturer/engine/win/mod.rs
@@ -62,7 +62,7 @@ impl GraphicsCaptureApiHandler for Capturer {
                     .expect("Failed to crop buffer");
 
                 // get raw frame buffer
-                let raw_frame_buffer = match cropped_buffer.as_raw_nopadding_buffer() {
+                let raw_frame_buffer = match cropped_buffer.as_nopadding_buffer() {
                     Ok(buffer) => buffer,
                     Err(_) => return Err(("Failed to get raw buffer").into()),
                 };


### PR DESCRIPTION
While compiling for windows, I get the following errors:
```rust
error[E0053]: method `new` has an incompatible type for trait
  --> C:\Users\makedon\.cargo\registry\src\index.crates.io-6f17d22bba15001f\scap-0.0.7\src\capturer\engine\win\mod.rs:39:25
   |
39 |     fn new(flag_values: Self::Flags) -> Result<Self, Self::Error> {
   |                         ^^^^^^^^^^^ expected `windows_capture::capture::Context<FlagStruct>`, found `FlagStruct`
   |
   = note: expected signature `fn(windows_capture::capture::Context<FlagStruct>) -> Result<_, _>`
              found signature `fn(FlagStruct) -> Result<_, _>`
help: change the parameter type to match the trait
   |
39 |     fn new(flag_values: windows_capture::capture::Context<FlagStruct>) -> Result<Self, Self::Error> {
   |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error[E0599]: no method named `as_raw_nopadding_buffer` found for struct `FrameBuffer` in the current scope
  --> C:\Users\makedon\.cargo\registry\src\index.crates.io-6f17d22bba15001f\scap-0.0.7\src\capturer\engine\win\mod.rs:65:61
   |
65 |                 let raw_frame_buffer = match cropped_buffer.as_raw_nopadding_buffer() {
   |                                                             ^^^^^^^^^^^^^^^^^^^^^^^
   |
help: there is a method `as_nopadding_buffer` with a similar name
   |
65 |                 let raw_frame_buffer = match cropped_buffer.as_nopadding_buffer() {
   |                                                             ~~~~~~~~~~~~~~~~~~~
```
This PR fixes both errors by following the compiler's suggestions (modifying the function to take a Context and using as_nopadding_buffer).