### PR TITLE
fix: rely on settings to draw windows capture indicator

### DIFF
--- a/src/capturer/engine/win/mod.rs
+++ b/src/capturer/engine/win/mod.rs
@@ -152,7 +152,7 @@ pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> WCStream {
         false => CursorCaptureSettings::WithoutCursor,
     };
 
-    let show_border = options.show_highlight {
+    let show_border = match options.show_highlight {
         true => DrawBorderSettings::WithBorder,
         false => DrawBorderSettings::WithoutBorder,
     }

--- a/src/capturer/engine/win/mod.rs
+++ b/src/capturer/engine/win/mod.rs
@@ -155,7 +155,7 @@ pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> WCStream {
     let show_border = match options.show_highlight {
         true => DrawBorderSettings::WithBorder,
         false => DrawBorderSettings::WithoutBorder,
-    }
+    };
 
     let settings = match target {
         Target::Display(display) => Settings::Display(WCSettings::new(

--- a/src/capturer/engine/win/mod.rs
+++ b/src/capturer/engine/win/mod.rs
@@ -152,11 +152,16 @@ pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> WCStream {
         false => CursorCaptureSettings::WithoutCursor,
     };
 
+    let show_border = options.show_highlight {
+        true => DrawBorderSettings::WithBorder,
+        false => DrawBorderSettings::WithoutBorder,
+    }
+
     let settings = match target {
         Target::Display(display) => Settings::Display(WCSettings::new(
             WCMonitor::from_raw_hmonitor(display.raw_handle.0),
             show_cursor,
-            DrawBorderSettings::Default,
+            show_border,
             color_format,
             FlagStruct {
                 tx,
@@ -166,7 +171,7 @@ pub fn create_capturer(options: &Options, tx: mpsc::Sender<Frame>) -> WCStream {
         Target::Window(window) => Settings::Window(WCSettings::new(
             WCWindow::from_raw_hwnd(window.raw_handle.0),
             show_cursor,
-            DrawBorderSettings::Default,
+            show_border,
             color_format,
             FlagStruct {
                 tx,


### PR DESCRIPTION
noticed that the `show_highlights` prop in the `Options` wasn't being passed onto the Windows capturer correctly, so made this quick PR.

Need someone to test this out before we merge.