### PR TITLE
Use more accurate DwmGetWindowAttribute for getting window bounds on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ sysinfo = "0.30.0"
 windows-capture = "1.3.6"
 windows = { version = "0.58", features = [
 	"Win32_Foundation",
+	"Win32_Graphics_Dwm",
 	"Win32_Graphics_Gdi",
 	"Win32_UI_HiDpi",
 	"Win32_UI_WindowsAndMessaging",


### PR DESCRIPTION
GetWindowRect() includes window drop shadows, which can cause attempts to screen capture outside of window boundaries, resulting in black bars

DwmGetWindowAttribute is more accurate, including the window frame, but nothing outside the window bounds.