### PR TITLE
fix: correct typo and replace deprecated method usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ fn main() {
         excluded_targets: None,
         output_type: scap::frame::FrameType::BGRAFrame,
         output_resolution: scap::capturer::Resolution::_720p,
-        source_rect: Some(Area {
+        crop_area: Some(Area {
             origin: Point { x: 0.0, y: 0.0 },
             size: Size {
                 width: 2000.0,
@@ -84,7 +84,7 @@ fn main() {
     };
 
     // Create Capturer
-    let mut capturer = Capturer::new(options);
+    let mut capturer = Capturer::build(options).unwrap();
 
     // Start Capture
     capturer.start_capture();


### PR DESCRIPTION
Hey there!

While integrating the library, I encountered an issue where `source_rect ` appears to have been replaced by `crop_area`. I’ve updated the usage accordingly.

Additionally, I replaced the use of ::new with ::build to align with the updated API.

