### PR TITLE
Upgrade Cidre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cidre"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b83f5e597a8fb4ba25eec2683aa3e89f9890dd7524622639a38e3f854c60eb"
+checksum = "c7a105a9a8dd9e625e1e5938aa8442f63551990bfb2ab4bd606b1b30ccbfd8cf"
 dependencies = [
  "cidre-macros",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cpal = "0.15.3"
 core-graphics-helmer-fork = "0.24.0"
 cocoa = "0.25.0"
 objc = "0.2.7"
-cidre = "0.9.2"
+cidre = "0.10.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 pipewire = "0.8.0"


### PR DESCRIPTION
Required to fix compile error while attempting to build Cap on macOS.

The issue is Cap's workspace has multiple of versions of Cidre which is causing issues. This PR upgrades the Cidre version in scap which should allow us to only have a single version in scope.

```
error[E0308]: mismatched types
   --> crates/media/src/sources/screen_capture.rs:718:25
    |
718 |                         sc::stream::OutputType::Audio => {
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `cidre::sc::stream::OutputType`, found `OutputType`
    |
note: two different versions of crate `cidre` are being used; two types coming from two different versions of the same crate are different types even if they look the same
   --> /Users/oscar/.cargo/git/checkouts/cidre-4fcea89888fe326d/517d097/cidre/src/sc/stream.rs:117:1
    |
117 | pub enum OutputType {
    | ^^^^^^^^^^^^^^^^^^^ this is the found type `OutputType`
    |
   ::: /Users/oscar/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cidre-0.9.2/src/sc/stream.rs:117:1
    |
117 | pub enum OutputType {
    | ^^^^^^^^^^^^^^^^^^^ this is the expected type `cidre::sc::stream::OutputType`
    |
   ::: crates/media/src/sources/screen_capture.rs:5:5
    |
5   | use scap::{
    |     ---- one version of crate `cidre` used here, as a dependency of crate `scap`
    |
   ::: crates/media/src/encoders/mp4_avassetwriter.rs:14:5
    |
14  | use cidre::{cm::SampleTimingInfo, objc::Obj, *};
    |     ----- one version of crate `cidre` used here, as a direct dependency of the current crate
    = help: you can use `cargo tree` to explore your dependency tree
```